### PR TITLE
Add error handling on load config / pot file

### DIFF
--- a/fern.ts
+++ b/fern.ts
@@ -175,8 +175,19 @@ await new Command()
 	.action(async (options: {[options: string]: string | number | boolean}, _args: string[]) =>
 	{
 		console.log(color.bold(color.green('Starting update...')));
-		config = JSON.parse(await Deno.readTextFile(path.resolve(path.join(`${options.configLocation}`, `${options.profileName}.json`))));
-		pot = JSON.parse(await Deno.readTextFile(path.resolve(path.join(`${options.configLocation}`, `${options.profileName}-pot.json`))));
+		
+		try {
+			config = JSON.parse(await Deno.readTextFile(path.resolve(path.join(`${options.configLocation}`, `${options.profileName}.json`))));
+		} catch {
+			console.log(color.bold(color.red('Error: Failed to load / parse config file.')))
+			Deno.exit(1)
+		}
+		try {
+			pot = JSON.parse(await Deno.readTextFile(path.resolve(path.join(`${options.configLocation}`, `${options.profileName}-pot.json`))));
+		} catch {
+			console.log(color.bold(color.red('Error: Failed to load / parse pot file.')))
+			Deno.exit(1)
+		}
 
 		if(config.update_pre_script)
 		{


### PR DESCRIPTION
Added explicit error message if fails to load or parse config / pot file.
<img width="555" alt="スクリーンショット 2022-05-23 10 21 31" src="https://user-images.githubusercontent.com/14804458/169726182-b2b0c6ba-c0f7-43b3-9ce6-b46f829d9ee2.png">
